### PR TITLE
Add async flag + move script to head when async

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install --save create-html
 #### `options`
 - `title`
 - `script`
+- `scriptAsync`
 - `css`
 - `lang`
 - `dir`
@@ -38,6 +39,7 @@ Example using all options:
 var html = createHTML({
   title: 'example',
   script: 'example.js',
+  scriptAsync: true,
   css: 'example.css',
   lang: 'en',
   dir: 'rtl',
@@ -111,6 +113,7 @@ Usage:
 Options:
   --title, -t        Page title
   --script, -s       JavaScript filename, optional
+  --script-async, -a Add async attribute to script tag
   --css, -c          CSS filename, optional
   --favicon, -f      Site favicon
   --lang, -l         Language of content

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@ var argv = parseArgs(process.argv.slice(2), {
     f: 'favicon',
     c: 'css',
     s: 'script',
+    a: 'script-async',
     o: 'output',
     h: 'help'
   },
@@ -30,6 +31,7 @@ Usage:
 Options:
   --title, -t        Page title
   --script, -s       JavaScript filename, optional
+  --script-async, -a Add async attribute to script tag
   --css, -c          CSS filename, optional
   --favicon, -f      Site favicon
   --lang, -l         Language of content
@@ -50,7 +52,7 @@ fs.writeFile(argv.output, createHTML(argv), function (err) {
     console.log(`
       Error:
         ${err}
-      
+
       Usage:
         ${usage}
     `)

--- a/cli.js
+++ b/cli.js
@@ -15,10 +15,13 @@ var argv = parseArgs(process.argv.slice(2), {
     f: 'favicon',
     c: 'css',
     s: 'script',
-    a: 'script-async',
+    a: ['script-async', 'scriptAsync'],
     o: 'output',
     h: 'help'
   },
+  boolean: [
+    'script-async'
+  ],
   default: {
     output: 'index.html'
   }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = function (opts) {
   var title = opts.title ? `<title>${opts.title}</title>` : ''
-  var script = opts.script ? `<script src="${opts.script}"></script>` : ''
+  var isAsync = !!opts.scriptAsync
+  var script = opts.script ? `<script src="${opts.script}"${isAsync ? ' async' : ''}></script>` : ''
   var favicon = opts.favicon ? `<link rel="icon" href="${opts.favicon}">` : ''
   var css = opts.css ? `<link rel="stylesheet" href="${opts.css}">` : ''
   var lang = opts.lang || 'en'
@@ -16,10 +17,10 @@ ${title}
 ${favicon}
 ${css}
 ${head}
+${script}
 </head>
 <body>
 ${body}
-${script}
 </body>
 </html>
 `

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function (opts) {
   var title = opts.title ? `<title>${opts.title}</title>` : ''
-  var isAsync = !!opts.scriptAsync
-  var script = opts.script ? `<script src="${opts.script}"${isAsync ? ' async' : ''}></script>` : ''
+  var headScript = (opts.script && opts.scriptAsync) ? `<script src="${opts.script}" async></script>` : ''
+  var bodyScript = (opts.script && !opts.scriptAsync)? `<script src="${opts.script}"></script>` : ''
   var favicon = opts.favicon ? `<link rel="icon" href="${opts.favicon}">` : ''
   var css = opts.css ? `<link rel="stylesheet" href="${opts.css}">` : ''
   var lang = opts.lang || 'en'
@@ -17,10 +17,11 @@ ${title}
 ${favicon}
 ${css}
 ${head}
-${script}
+${headScript}
 </head>
 <body>
 ${body}
+${bodyScript}
 </body>
 </html>
 `

--- a/tests/fixtures/async.html
+++ b/tests/fixtures/async.html
@@ -10,5 +10,6 @@
 </head>
 <body>
 
+
 </body>
 </html>

--- a/tests/fixtures/async.html
+++ b/tests/fixtures/async.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
 <title>example</title>
 <meta charset="utf-8">
-<link rel="icon" href="favicon.png">
 
 
 
+<script src="example.js" async></script>
 </head>
 <body>
 

--- a/tests/fixtures/body.html
+++ b/tests/fixtures/body.html
@@ -10,5 +10,6 @@
 </head>
 <body>
 <p>example</p>
+
 </body>
 </html>

--- a/tests/fixtures/body.html
+++ b/tests/fixtures/body.html
@@ -6,9 +6,9 @@
 
 
 
+
 </head>
 <body>
 <p>example</p>
-
 </body>
 </html>

--- a/tests/fixtures/css.html
+++ b/tests/fixtures/css.html
@@ -10,5 +10,6 @@
 </head>
 <body>
 
+
 </body>
 </html>

--- a/tests/fixtures/css.html
+++ b/tests/fixtures/css.html
@@ -6,9 +6,9 @@
 
 <link rel="stylesheet" href="example.css">
 
+
 </head>
 <body>
-
 
 </body>
 </html>

--- a/tests/fixtures/favicon.html
+++ b/tests/fixtures/favicon.html
@@ -10,5 +10,6 @@
 </head>
 <body>
 
+
 </body>
 </html>

--- a/tests/fixtures/head.html
+++ b/tests/fixtures/head.html
@@ -10,5 +10,6 @@
 </head>
 <body>
 
+
 </body>
 </html>

--- a/tests/fixtures/head.html
+++ b/tests/fixtures/head.html
@@ -6,9 +6,9 @@
 
 
 <meta name="description" content="example description">
+
 </head>
 <body>
-
 
 </body>
 </html>

--- a/tests/fixtures/lang.html
+++ b/tests/fixtures/lang.html
@@ -10,5 +10,6 @@
 </head>
 <body>
 
+
 </body>
 </html>

--- a/tests/fixtures/lang.html
+++ b/tests/fixtures/lang.html
@@ -6,9 +6,9 @@
 
 
 
+
 </head>
 <body>
-
 
 </body>
 </html>

--- a/tests/fixtures/script.html
+++ b/tests/fixtures/script.html
@@ -6,9 +6,10 @@
 
 
 
-<script src="example.js"></script>
+<script src="example.js" async></script>
 </head>
 <body>
+
 
 </body>
 </html>

--- a/tests/fixtures/script.html
+++ b/tests/fixtures/script.html
@@ -6,9 +6,9 @@
 
 
 
+<script src="example.js"></script>
 </head>
 <body>
 
-<script src="example.js"></script>
 </body>
 </html>

--- a/tests/fixtures/title.html
+++ b/tests/fixtures/title.html
@@ -10,5 +10,6 @@
 </head>
 <body>
 
+
 </body>
 </html>

--- a/tests/fixtures/title.html
+++ b/tests/fixtures/title.html
@@ -6,9 +6,9 @@
 
 
 
+
 </head>
 <body>
-
 
 </body>
 </html>

--- a/tests/index.js
+++ b/tests/index.js
@@ -94,3 +94,17 @@ test('script', function (t) {
     t.end()
   })
 })
+
+test('async script', function (t) {
+  var html = createHTML({
+    title: 'example',
+    script: 'example.js',
+    scriptAsync: true
+  })
+
+  fs.readFile(path.join(__dirname, '/fixtures/async.html'), 'utf8', function (err, file) {
+    t.notOk(err)
+    t.equal(html, file)
+    t.end()
+  })
+})


### PR DESCRIPTION
This PR adds the async flag mentioned in #4. The script is synchronous by default (while we're at it maybe should switch to async by default. then the flags would be `--sync` etc. instead). And I've moved the script to the head *whether or not it's async*. Is that desirable? This is really two separate options (head or body + sync or async), but maybe it's overkill to actually implement as such.

To be explicit, enabled by this PR are:

- head + sync (new default)
- head + async

Not enabled:

- body + sync (current default)
- body + async

cc @yoshuawuyts