### PR TITLE
allow for async css loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm install --save create-html
 - `script`
 - `scriptAsync`
 - `css`
+- `cssAsync`
 - `lang`
 - `dir`
 - `head`

--- a/cli.js
+++ b/cli.js
@@ -14,6 +14,7 @@ var argv = parseArgs(process.argv.slice(2), {
     H: 'head',
     f: 'favicon',
     c: 'css',
+    C: ['css-async', 'cssAsync'],
     s: 'script',
     a: ['script-async', 'scriptAsync'],
     o: 'output',
@@ -23,7 +24,8 @@ var argv = parseArgs(process.argv.slice(2), {
     'output'
   ],
   boolean: [
-    'script-async'
+    'script-async',
+    'css-async'
   ]
 })
 
@@ -36,6 +38,7 @@ Options:
   --script, -s       JavaScript filename, optional
   --script-async, -a Add async attribute to script tag
   --css, -c          CSS filename, optional
+  --css-async, -C    Load CSS asynchronously
   --favicon, -f      Site favicon
   --lang, -l         Language of content
   --dir, -d          Direction of content

--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@ module.exports = function (opts) {
   var headScript = (opts.script && opts.scriptAsync) ? `<script src="${opts.script}" async></script>` : ''
   var bodyScript = (opts.script && !opts.scriptAsync) ? `<script src="${opts.script}"></script>` : ''
   var favicon = opts.favicon ? `<link rel="icon" href="${opts.favicon}">` : ''
-  var css = opts.css ? `<link rel="stylesheet" href="${opts.css}">` : ''
+  var css = opts.css
+    ? opts.cssAsync
+      ? `<link rel="stylesheet" href="${opts.css}" media="none" onload="if(media!=='all')media='all'">`
+      : `<link rel="stylesheet" href="${opts.css}">`
+    : ''
   var lang = opts.lang || 'en'
   var dir = opts.dir || 'ltr'
   var head = opts.head || ''


### PR DESCRIPTION
Allows async loading of CSS. Coupled with critical CSS inlining it allows us to achieve a better lighthouse score.

### screenshot

This the thingy we're trying to fix (:
<img width="950" alt="screen shot 2017-07-09 at 15 55 15" src="https://user-images.githubusercontent.com/2467194/27994452-1618961a-64bf-11e7-8360-d146b6ea6a30.png">
