### PR TITLE
Place css at the end of head / meta tag before css link tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ module.exports = function (opts) {
 ${title}
 <meta charset="utf-8">
 ${favicon}
-${css}
 ${head}
+${css}
 ${headScript}
 </head>
 <body>

--- a/tests/fixtures/css.html
+++ b/tests/fixtures/css.html
@@ -4,8 +4,8 @@
 <title>example</title>
 <meta charset="utf-8">
 
-<link rel="stylesheet" href="example.css">
 
+<link rel="stylesheet" href="example.css">
 
 </head>
 <body>

--- a/tests/fixtures/head.html
+++ b/tests/fixtures/head.html
@@ -4,8 +4,8 @@
 <title>example</title>
 <meta charset="utf-8">
 
-
 <meta name="description" content="example description">
+
 
 </head>
 <body>


### PR DESCRIPTION
**css link tag will be placed after `${head}`**

## How does it benefit?

I use [grunt-bower-install](https://www.npmjs.com/package/grunt-bower-install) which will add link tags for all the css files used in the project automatically to the html file.

It'll insert the link tags between the comment `<!-- bower:css --><!-- endbower -->`

Before running `bowerInstall` I generate html files using `create-html`. It is important that the generated html has `<!-- bower:css --><!-- endbower -->` in it.

I added it by passing it as value of `head`

    css: 'src/css/style.css',
    head: '<!-- bower:css --><!-- endbower -->'

This will generate following html

    <link rel="stylesheet" href="src/css/style.css">
    <!-- bower:css -->
    <link rel="stylesheet" href="../bower_components/materialize/dist/css/materialize.css" />
    <!-- endbower -->

My custom css file is placed before bower_components whereas it is more appropriate for it to be after bower_components.

`head` is also used to add meta tags and **it is more followed convention where meta tags are before css link tags**

## What this PR changes?

Interchanged `${css}` and `${head}` in `index.js`