### PR TITLE
Adding support for multiple css and js files

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ var stream = fromString(html)
 stream.pipe(hs).pipe(process.stdout)
 ```
 
+
+### Multiple CSS and Javascript Files
+
+Multiple script and stylesheets can be added by sending an array instead of a string:
+
+```js
+var html = createHTML({
+  css: ['sheet1.css', 'sheet2.css'],
+  script: ['script1.css', 'script2.css'],
+})
+```
+
 ## CLI
 
 This module comes with a simple command-line tool for creating html files.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Multiple script and stylesheets can be added by sending an array instead of a st
 ```js
 var html = createHTML({
   css: ['sheet1.css', 'sheet2.css'],
-  script: ['script1.css', 'script2.css'],
+  script: ['script1.js', 'script2.js']
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,43 @@
+function buildStylesheets (sheets, async) {
+  var output = ''
+  if (!sheets) return output
+
+  if (typeof sheets === 'string') {
+    sheets = [sheets]
+  }
+
+  sheets.forEach(function (sheet) {
+    output += !async
+      ? `<link rel="stylesheet" href="${sheet}">`
+      : `<link rel="stylesheet" href="${sheet}" media="none" onload="if(media!=='all')media='all'">`
+  })
+
+  return output
+}
+
+function buildScripts (scripts, async) {
+  var output = ''
+  if (!scripts) return output
+
+  if (typeof scripts === 'string') {
+    scripts = [scripts]
+  }
+
+  scripts.forEach(function (script) {
+    output += !async
+      ? `<script src="${script}"></script>`
+      : `<script src="${script}" async></script>`
+  })
+
+  return output
+}
+
 module.exports = function (opts) {
   var title = opts.title ? `<title>${opts.title}</title>` : ''
-  var headScript = (opts.script && opts.scriptAsync) ? `<script src="${opts.script}" async></script>` : ''
-  var bodyScript = (opts.script && !opts.scriptAsync) ? `<script src="${opts.script}"></script>` : ''
+  var headScript = (opts.script && opts.scriptAsync) ? buildScripts(opts.script, opts.scriptAsync) : ''
+  var bodyScript = (opts.script && !opts.scriptAsync) ? buildScripts(opts.script, opts.scriptAsync) : ''
   var favicon = opts.favicon ? `<link rel="icon" href="${opts.favicon}">` : ''
-  var css = opts.css
-    ? opts.cssAsync
-      ? `<link rel="stylesheet" href="${opts.css}" media="none" onload="if(media!=='all')media='all'">`
-      : `<link rel="stylesheet" href="${opts.css}">`
-    : ''
+  var css = buildStylesheets(opts.css, opts.cssAsync)
   var lang = opts.lang || 'en'
   var dir = opts.dir || 'ltr'
   var head = opts.head || ''

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ function buildStylesheets (sheets, async) {
 
   sheets.forEach(function (sheet) {
     output += !async
-      ? `<link rel="stylesheet" href="${sheet}">`
-      : `<link rel="stylesheet" href="${sheet}" media="none" onload="if(media!=='all')media='all'">`
+      ? `<link rel="stylesheet" href="${sheet}">\n`
+      : `<link rel="stylesheet" href="${sheet}" media="none" onload="if(media!=='all')media='all'">\n`
   })
 
   return output
@@ -25,8 +25,8 @@ function buildScripts (scripts, async) {
 
   scripts.forEach(function (script) {
     output += !async
-      ? `<script src="${script}"></script>`
-      : `<script src="${script}" async></script>`
+      ? `<script src="${script}"></script>\n`
+      : `<script src="${script}" async></script>\n`
   })
 
   return output

--- a/package.json
+++ b/package.json
@@ -1,15 +1,64 @@
 {
-  "name": "create-html",
-  "version": "4.0.0",
-  "description": "create the content of an html file with one function call",
-  "main": "index.js",
+  "_args": [
+    [
+      {
+        "raw": "create-html@^4.0.0",
+        "scope": null,
+        "escapedName": "create-html",
+        "name": "create-html",
+        "rawSpec": "^4.0.0",
+        "spec": ">=4.0.0 <5.0.0",
+        "type": "range"
+      },
+      "/Users/emcniece/Code/ionic/aurora-app"
+    ]
+  ],
+  "_from": "create-html@>=4.0.0 <5.0.0",
+  "_id": "create-html@4.0.0",
+  "_inCache": true,
+  "_location": "/create-html",
+  "_nodeVersion": "6.11.1",
+  "_npmOperationalInternal": {
+    "host": "s3://npm-registry-packages",
+    "tmp": "tmp/create-html-4.0.0.tgz_1504387270191_0.23340277816168964"
+  },
+  "_npmUser": {
+    "name": "sethvincent",
+    "email": "sethvincent@gmail.com"
+  },
+  "_npmVersion": "5.3.0",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "create-html@^4.0.0",
+    "scope": null,
+    "escapedName": "create-html",
+    "name": "create-html",
+    "rawSpec": "^4.0.0",
+    "spec": ">=4.0.0 <5.0.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "#DEV:/"
+  ],
+  "_resolved": "https://npm.limbicmedia.ca/create-html/-/create-html-4.0.0.tgz",
+  "_shasum": "adaba45f4347cf08a725dfc633e4b785445e1c09",
+  "_shrinkwrap": null,
+  "_spec": "create-html@^4.0.0",
+  "_where": "/Users/emcniece/Code/ionic/aurora-app",
+  "author": {
+    "name": "sethvincent"
+  },
   "bin": {
     "create-html": "cli.js"
+  },
+  "bugs": {
+    "url": "https://github.com/sethvincent/create-html/issues"
   },
   "dependencies": {
     "exit": "^0.1.2",
     "minimist": "^1.2.0"
   },
+  "description": "create the content of an html file with one function call",
   "devDependencies": {
     "from2-string": "^1.1.0",
     "hyperstream": "^1.2.2",
@@ -18,24 +67,39 @@
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1"
   },
-  "scripts": {
-    "lint": "standard",
-    "test": "npm run lint && node tests/index.js | tap-spec"
+  "directories": {},
+  "dist": {
+    "integrity": "sha512-STB2IY1nb0ho29oQsuMw/S7vcwxYYBV20T3cb1azZW2a59PsKwyIvd7DtAlyG20GZ2jtUw+T38hqky0O1fm0QQ==",
+    "shasum": "adaba45f4347cf08a725dfc633e4b785445e1c09",
+    "tarball": "https://npm.limbicmedia.ca/create-html/-/create-html-4.0.0.tgz"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/sethvincent/create-html.git"
-  },
+  "gitHead": "4bedce26e13ae644a80be0bd0684df223d8959bb",
+  "homepage": "https://github.com/sethvincent/create-html#readme",
   "keywords": [
     "html",
     "static",
     "sites",
     "index.html"
   ],
-  "author": "sethvincent",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/sethvincent/create-html/issues"
+  "main": "index.js",
+  "maintainers": [
+    {
+      "name": "sethvincent",
+      "email": "sethvincent@gmail.com"
+    }
+  ],
+  "name": "create-html",
+  "optionalDependencies": {},
+  "readme": "# create-html\n\nCreate the content of an html file with one function call.\n\n[![npm][npm-image]][npm-url]\n[![travis][travis-image]][travis-url]\n[![standard][standard-image]][standard-url]\n[![conduct][conduct]][conduct-url]\n\n[npm-image]: https://img.shields.io/npm/v/create-html.svg?style=flat-square\n[npm-url]: https://www.npmjs.com/package/create-html\n[travis-image]: https://img.shields.io/travis/sethvincent/create-html.svg?style=flat-square\n[travis-url]: https://travis-ci.org/sethvincent/create-html\n[standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square\n[standard-url]: http://npm.im/standard\n[conduct]: https://img.shields.io/badge/code%20of%20conduct-contributor%20covenant-green.svg?style=flat-square\n[conduct-url]: CONDUCT.md\n\n## Install\n\n```\nnpm install --save create-html\n```\n\n## Usage\n\n### `createHTML(options)`\n\n#### `options`\n- `title`\n- `script`\n- `scriptAsync`\n- `css`\n- `cssAsync`\n- `lang`\n- `dir`\n- `head`\n- `body`\n- `favicon`\n\n## Examples\n\nSimple example that create an html file with the title `example`:\n\n```js\nvar html = createHTML({\n  title: 'example'\n})\n```\n\nExample using all options:\n\n```js\nvar html = createHTML({\n  title: 'example',\n  script: 'example.js',\n  scriptAsync: true,\n  css: 'example.css',\n  lang: 'en',\n  dir: 'rtl',\n  head: '<meta name=\"description\" content=\"example\">',\n  body: '<p>example</p>',\n  favicon: 'favicon.png'\n})\n```\n\nCreate a file with the html contents using the fs module:\n\n```js\nvar fs = require('fs')\nvar createHTML = require('create-html')\n\nvar html = createHTML({\n  title: 'example'\n})\n\nfs.writeFile('index.html', html, function (err) {\n  if (err) console.log(err)\n})\n```\n\nCreate a stream by pairing this module with [`from2-string`](http://npmjs.com/from2-string):\n\n```js\nvar fromString = require('from2-string')\nvar createHTML = require('create-html')\n\nvar html = createHTML({\n  title: 'example'\n})\n\nvar stream = fromString(html)\nstream.pipe(process.stdout)\n```\n\nPipe content into the html that this module generates by using from2-string and [`hyperstream`](http://npmjs.com/hyperstream)\n\n```js\nvar fs = require('fs')\nvar fromString = require('from2-string')\nvar hyperstream = require('hyperstream')\nvar createHTML = require('./index')\n\nvar html = createHTML({\n  title: 'example'\n})\n\nvar hs = hyperstream({\n  'body': fs.createReadStream('some.html')\n})\n\nvar stream = fromString(html)\nstream.pipe(hs).pipe(process.stdout)\n```\n\n## CLI\n\nThis module comes with a simple command-line tool for creating html files.\n\nInstall it globally with `npm i -g create-html`\n\n### Usage:\n\n```\nUsage:\n  create-html [options]\n\nOptions:\n  --title, -t        Page title\n  --script, -s       JavaScript filename, optional\n  --script-async, -a Add async attribute to script tag\n  --css, -c          CSS filename, optional\n  --favicon, -f      Site favicon\n  --lang, -l         Language of content\n  --dir, -d          Direction of content\n  --head, -H         Content to insert into <head> tag\n  --body, -b         Content to insert into <body> tag\n  --output, -o       File name. optional. default: stdout\n  --help, -h         Show this help message\n```\n\n### Example:\n\n```\ncreate-html --title \"an example html file\"\n```\n\n### See also\n- [simple-html-index](https://github.com/mattdesl/simple-html-index)\n\n## License\n[MIT](LICENSE.md)\n",
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sethvincent/create-html.git"
   },
-  "homepage": "https://github.com/sethvincent/create-html#readme"
+  "scripts": {
+    "lint": "standard",
+    "test": "npm run lint && node tests/index.js | tap-spec"
+  },
+  "version": "4.0.0"
 }

--- a/tests/fixtures/async-multiple.html
+++ b/tests/fixtures/async-multiple.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+<head>
+<title>example</title>
+<meta charset="utf-8">
+
+
+
+<script src="example1.js" async></script><script src="example2.js" async></script>
+</head>
+<body>
+
+
+</body>
+</html>

--- a/tests/fixtures/async-multiple.html
+++ b/tests/fixtures/async-multiple.html
@@ -6,7 +6,9 @@
 
 
 
-<script src="example1.js" async></script><script src="example2.js" async></script>
+<script src="example1.js" async></script>
+<script src="example2.js" async></script>
+
 </head>
 <body>
 

--- a/tests/fixtures/async.html
+++ b/tests/fixtures/async.html
@@ -7,6 +7,7 @@
 
 
 <script src="example.js" async></script>
+
 </head>
 <body>
 

--- a/tests/fixtures/css-multiple.html
+++ b/tests/fixtures/css-multiple.html
@@ -5,7 +5,9 @@
 <meta charset="utf-8">
 
 
-<link rel="stylesheet" href="example1.css"><link rel="stylesheet" href="example2.css">
+<link rel="stylesheet" href="example1.css">
+<link rel="stylesheet" href="example2.css">
+
 
 </head>
 <body>

--- a/tests/fixtures/css-multiple.html
+++ b/tests/fixtures/css-multiple.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+<head>
+<title>example</title>
+<meta charset="utf-8">
+
+
+<link rel="stylesheet" href="example1.css"><link rel="stylesheet" href="example2.css">
+
+</head>
+<body>
+
+
+</body>
+</html>

--- a/tests/fixtures/css.html
+++ b/tests/fixtures/css.html
@@ -7,6 +7,7 @@
 
 <link rel="stylesheet" href="example.css">
 
+
 </head>
 <body>
 

--- a/tests/fixtures/script-multiple.html
+++ b/tests/fixtures/script-multiple.html
@@ -10,6 +10,8 @@
 </head>
 <body>
 
-<script src="example1.js"></script><script src="example2.js"></script>
+<script src="example1.js"></script>
+<script src="example2.js"></script>
+
 </body>
 </html>

--- a/tests/fixtures/script-multiple.html
+++ b/tests/fixtures/script-multiple.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+<head>
+<title>example</title>
+<meta charset="utf-8">
+
+
+
+
+</head>
+<body>
+
+<script src="example1.js"></script><script src="example2.js"></script>
+</body>
+</html>

--- a/tests/fixtures/script.html
+++ b/tests/fixtures/script.html
@@ -11,5 +11,6 @@
 <body>
 
 <script src="example.js"></script>
+
 </body>
 </html>

--- a/tests/index.js
+++ b/tests/index.js
@@ -28,6 +28,19 @@ test('css', function (t) {
   })
 })
 
+test('multiple css', function (t) {
+  var html = createHTML({
+    title: 'example',
+    css: ['example1.css', 'example2.css']
+  })
+
+  fs.readFile(path.join(__dirname, '/fixtures/css-multiple.html'), 'utf8', function (err, file) {
+    t.notOk(err)
+    t.equal(html, file)
+    t.end()
+  })
+})
+
 test('lang', function (t) {
   var html = createHTML({
     title: 'example',
@@ -93,6 +106,19 @@ test('script', function (t) {
   })
 })
 
+test('multiple script', function (t) {
+  var html = createHTML({
+    title: 'example',
+    script: ['example1.js', 'example2.js']
+  })
+
+  fs.readFile(path.join(__dirname, '/fixtures/script-multiple.html'), 'utf8', function (err, file) {
+    t.notOk(err)
+    t.equal(html, file)
+    t.end()
+  })
+})
+
 test('async script', function (t) {
   var html = createHTML({
     title: 'example',
@@ -101,6 +127,20 @@ test('async script', function (t) {
   })
 
   fs.readFile(path.join(__dirname, '/fixtures/async.html'), 'utf8', function (err, file) {
+    t.notOk(err)
+    t.equal(html, file)
+    t.end()
+  })
+})
+
+test('multiple async script', function (t) {
+  var html = createHTML({
+    title: 'example',
+    script: ['example1.js', 'example2.js'],
+    scriptAsync: true
+  })
+
+  fs.readFile(path.join(__dirname, '/fixtures/async-multiple.html'), 'utf8', function (err, file) {
     t.notOk(err)
     t.equal(html, file)
     t.end()


### PR DESCRIPTION
Threw in a couple of functions for handling arrays of css and js files:

```js
var html = createHTML({
  css: ['sheet1.css', 'sheet2.css'],
  script: ['script1.css', 'script2.css'],
})
```

Includes tests, linting and a README update.

I didn't update package.json `readme` though... not sure how that is generated.

Resolves https://github.com/sethvincent/create-html/issues/12